### PR TITLE
PAE-278 - Upgrade requirements to work on Python 3.

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -3,13 +3,10 @@
 
 Django
 edx-opaque-keys
-djangorestframework
+djangorestframework==3.9.4
 edx-completion
-django-model-utils
 
 # These are the plugin requirements.
-# These constraints are added here to work with setup.py's `install_requires`.
-# Python 2.7 supported and tested versions.
+# Add here any constraint needed to work with setup.py's `install_requires`.
 google-api-python-client
 google-cloud-bigquery
-cachetools<4.0.0

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -5,30 +5,29 @@
 #    make upgrade
 #
 appdirs==1.4.4            # via fs
-backports.os==0.1.1       # via fs
-cachetools==3.1.1         # via -c requirements/constraints.txt, -r requirements/base.in, google-auth
+cachetools==4.1.1         # via google-auth
 certifi==2020.6.20        # via requests
+cffi==1.14.2              # via cryptography, google-crc32c
 chardet==3.0.4            # via requests
-crcmod==1.7               # via google-resumable-media
-django-model-utils==3.0.0  # via -c requirements/constraints.txt, -r requirements/base.in, edx-completion
+cryptography==3.1         # via pyjwt
+django-model-utils==4.0.0  # via edx-completion
 django-waffle==2.0.0      # via edx-django-utils, edx-drf-extensions
-django==1.11.29           # via -c requirements/constraints.txt, -r requirements/base.in, django-model-utils, edx-completion, edx-django-utils, edx-drf-extensions, edx-opaque-keys, rest-condition
-djangorestframework-jwt==1.11.0  # via edx-drf-extensions
-djangorestframework==3.6.3  # via -c requirements/constraints.txt, -r requirements/base.in, edx-completion, edx-drf-extensions, rest-condition
-edx-completion==2.0.0     # via -c requirements/constraints.txt, -r requirements/base.in
+django==2.2.16            # via -c requirements/constraints.txt, -r requirements/base.in, django-model-utils, drf-jwt, edx-completion, edx-django-utils, edx-drf-extensions, edx-opaque-keys, rest-condition
+djangorestframework==3.9.4  # via -c requirements/constraints.txt, -r requirements/base.in, drf-jwt, edx-completion, edx-drf-extensions, rest-condition
+drf-jwt==1.17.1           # via edx-drf-extensions
+edx-completion==3.2.4     # via -r requirements/base.in
 edx-django-utils==3.8.0   # via edx-drf-extensions
-edx-drf-extensions==2.4.6  # via edx-completion
-edx-opaque-keys==0.4.4    # via -c requirements/constraints.txt, -r requirements/base.in, edx-completion, edx-drf-extensions
-enum34==1.1.10            # via fs, google-cloud-bigquery
+edx-drf-extensions==6.1.2  # via edx-completion
+edx-opaque-keys[django]==2.1.1  # via -r requirements/base.in, edx-completion, edx-drf-extensions
 fs==2.4.11                # via xblock
 future==0.18.2            # via pyjwkest
-futures==3.3.0 ; python_version == "2.7"  # via -c requirements/constraints.txt, google-api-core
-google-api-core==1.22.1   # via google-api-python-client, google-cloud-bigquery, google-cloud-core
-google-api-python-client==1.11.0  # via -c requirements/constraints.txt, -r requirements/base.in
+google-api-core==1.22.2   # via google-api-python-client, google-cloud-bigquery, google-cloud-core
+google-api-python-client==1.11.0  # via -r requirements/base.in
 google-auth-httplib2==0.0.4  # via google-api-python-client
-google-auth==1.21.0       # via google-api-core, google-api-python-client, google-auth-httplib2
-google-cloud-bigquery==1.27.2  # via -c requirements/constraints.txt, -r requirements/base.in
+google-auth==1.21.1       # via google-api-core, google-api-python-client, google-auth-httplib2
+google-cloud-bigquery==1.27.2  # via -r requirements/base.in
 google-cloud-core==1.4.1  # via google-cloud-bigquery
+google-crc32c==1.0.0      # via google-resumable-media
 google-resumable-media==1.0.0  # via google-cloud-bigquery
 googleapis-common-protos==1.52.0  # via google-api-core
 httplib2==0.18.1          # via google-api-python-client, google-auth-httplib2
@@ -38,23 +37,24 @@ markupsafe==1.1.1         # via xblock
 newrelic==5.18.0.148      # via edx-django-utils
 pbr==5.5.0                # via stevedore
 protobuf==3.13.0          # via google-api-core, googleapis-common-protos
-psutil==1.2.1             # via edx-django-utils, edx-drf-extensions
+psutil==5.7.2             # via edx-django-utils
 pyasn1-modules==0.2.8     # via google-auth
 pyasn1==0.4.8             # via pyasn1-modules, rsa
+pycparser==2.20           # via cffi
 pycryptodomex==3.9.8      # via pyjwkest
-pyjwkest==1.3.2           # via edx-drf-extensions
-pyjwt==1.7.1              # via djangorestframework-jwt
+pyjwkest==1.4.2           # via edx-drf-extensions
+pyjwt[crypto]==1.7.1      # via drf-jwt
 pymongo==3.11.0           # via edx-opaque-keys
 python-dateutil==2.8.1    # via edx-drf-extensions, xblock
 pytz==2020.1              # via django, edx-completion, fs, google-api-core, xblock
 pyyaml==5.3.1             # via xblock
 requests==2.24.0          # via edx-drf-extensions, google-api-core, pyjwkest
 rest-condition==1.0.3     # via edx-drf-extensions
-rsa==4.5                  # via google-auth
+rsa==4.6                  # via google-auth
 semantic-version==2.8.5   # via edx-drf-extensions
-six==1.15.0               # via edx-drf-extensions, edx-opaque-keys, fs, google-api-core, google-api-python-client, google-auth, google-auth-httplib2, google-cloud-bigquery, google-resumable-media, protobuf, pyjwkest, python-dateutil, stevedore, xblock
-stevedore==1.32.0         # via edx-django-utils, edx-opaque-keys
-typing==3.7.4.3           # via fs
+six==1.15.0               # via cryptography, edx-drf-extensions, edx-opaque-keys, fs, google-api-core, google-api-python-client, google-auth, google-auth-httplib2, google-cloud-bigquery, google-resumable-media, protobuf, pyjwkest, python-dateutil, xblock
+sqlparse==0.3.1           # via django
+stevedore==3.2.1          # via edx-django-utils, edx-opaque-keys
 uritemplate==3.0.1        # via google-api-python-client
 urllib3==1.25.10          # via requests
 web-fragments==0.3.2      # via xblock

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -8,21 +8,8 @@
 # pin when possible.  Writing an issue against the offending project and
 # linking to it here is good.
 
-# Django version 2.0.0 dropped support for python 2.7.
-Django<2.0
-
-# Already in python3 standard library.
-futures; python_version == "2.7"
+# Stay on the latest LTS release of Django
+Django<2.3
 
 # edx-platform version compatibility.
-edx-opaque-keys==0.4.4
-djangorestframework==3.6.3
-edx-completion==2.0.0
-django-model-utils==3.0.0
-pylint==1.9.3
-pycodestyle==2.5.0
-
-# Python 2.7 supported versions.
-google-api-python-client<=1.11.0
-google-cloud-bigquery<=1.27.2
-cachetools<4.0.0
+djangorestframework==3.9.4

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,5 +4,5 @@
 #
 #    make upgrade
 #
-bump2version==0.5.11      # via bumpversion
+bump2version==1.0.0       # via bumpversion
 bumpversion==0.6.0        # via -r requirements/dev.in

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -5,65 +5,63 @@
 #    make upgrade
 #
 appdirs==1.4.4            # via -r requirements/base.txt, fs
-astroid==1.6.6            # via pylint
-backports.functools-lru-cache==1.6.1  # via astroid, isort, pylint
-backports.os==0.1.1       # via -r requirements/base.txt, fs
-cachetools==3.1.1         # via -c requirements/constraints.txt, -r requirements/base.txt, google-auth
+astroid==2.4.2            # via pylint
+cachetools==4.1.1         # via -r requirements/base.txt, google-auth
 certifi==2020.6.20        # via -r requirements/base.txt, requests
+cffi==1.14.2              # via -r requirements/base.txt, cryptography, google-crc32c
 chardet==3.0.4            # via -r requirements/base.txt, requests
-configparser==4.0.2       # via pylint
-crcmod==1.7               # via -r requirements/base.txt, google-resumable-media
-django-model-utils==3.0.0  # via -c requirements/constraints.txt, -r requirements/base.txt, edx-completion
+cryptography==3.1         # via -r requirements/base.txt, pyjwt
+django-model-utils==4.0.0  # via -r requirements/base.txt, edx-completion
 django-waffle==2.0.0      # via -r requirements/base.txt, edx-django-utils, edx-drf-extensions
-django==1.11.29           # via -c requirements/constraints.txt, -r requirements/base.txt, django-model-utils, edx-completion, edx-django-utils, edx-drf-extensions, edx-opaque-keys, rest-condition
-djangorestframework-jwt==1.11.0  # via -r requirements/base.txt, edx-drf-extensions
-djangorestframework==3.6.3  # via -c requirements/constraints.txt, -r requirements/base.txt, edx-completion, edx-drf-extensions, rest-condition
-edx-completion==2.0.0     # via -c requirements/constraints.txt, -r requirements/base.txt
+django==2.2.16            # via -c requirements/constraints.txt, -r requirements/base.txt, django-model-utils, drf-jwt, edx-completion, edx-django-utils, edx-drf-extensions, edx-opaque-keys, rest-condition
+djangorestframework==3.9.4  # via -c requirements/constraints.txt, -r requirements/base.txt, drf-jwt, edx-completion, edx-drf-extensions, rest-condition
+drf-jwt==1.17.1           # via -r requirements/base.txt, edx-drf-extensions
+edx-completion==3.2.4     # via -r requirements/base.txt
 edx-django-utils==3.8.0   # via -r requirements/base.txt, edx-drf-extensions
-edx-drf-extensions==2.4.6  # via -r requirements/base.txt, edx-completion
-edx-opaque-keys==0.4.4    # via -c requirements/constraints.txt, -r requirements/base.txt, edx-completion, edx-drf-extensions
-enum34==1.1.10            # via -r requirements/base.txt, astroid, fs, google-cloud-bigquery
+edx-drf-extensions==6.1.2  # via -r requirements/base.txt, edx-completion
+edx-opaque-keys[django]==2.1.1  # via -r requirements/base.txt, edx-completion, edx-drf-extensions
 fs==2.4.11                # via -r requirements/base.txt, xblock
-future==0.18.2            # via -r requirements/base.txt, backports.os, pyjwkest
-futures==3.3.0 ; python_version == "2.7"  # via -c requirements/constraints.txt, -r requirements/base.txt, google-api-core, isort
-google-api-core==1.22.1   # via -r requirements/base.txt, google-api-python-client, google-cloud-bigquery, google-cloud-core
-google-api-python-client==1.11.0  # via -c requirements/constraints.txt, -r requirements/base.txt
+future==0.18.2            # via -r requirements/base.txt, pyjwkest
+google-api-core==1.22.2   # via -r requirements/base.txt, google-api-python-client, google-cloud-bigquery, google-cloud-core
+google-api-python-client==1.11.0  # via -r requirements/base.txt
 google-auth-httplib2==0.0.4  # via -r requirements/base.txt, google-api-python-client
-google-auth==1.21.0       # via -r requirements/base.txt, google-api-core, google-api-python-client, google-auth-httplib2
-google-cloud-bigquery==1.27.2  # via -c requirements/constraints.txt, -r requirements/base.txt
+google-auth==1.21.1       # via -r requirements/base.txt, google-api-core, google-api-python-client, google-auth-httplib2
+google-cloud-bigquery==1.27.2  # via -r requirements/base.txt
 google-cloud-core==1.4.1  # via -r requirements/base.txt, google-cloud-bigquery
+google-crc32c==1.0.0      # via -r requirements/base.txt, google-resumable-media
 google-resumable-media==1.0.0  # via -r requirements/base.txt, google-cloud-bigquery
 googleapis-common-protos==1.52.0  # via -r requirements/base.txt, google-api-core
 httplib2==0.18.1          # via -r requirements/base.txt, google-api-python-client, google-auth-httplib2
 idna==2.10                # via -r requirements/base.txt, requests
-isort==4.3.21             # via pylint
-lazy-object-proxy==1.5.1  # via astroid
+isort==5.5.1              # via pylint
+lazy-object-proxy==1.4.3  # via astroid
 lxml==4.5.2               # via -r requirements/base.txt, xblock
 markupsafe==1.1.1         # via -r requirements/base.txt, xblock
 mccabe==0.6.1             # via pylint
 newrelic==5.18.0.148      # via -r requirements/base.txt, edx-django-utils
 pbr==5.5.0                # via -r requirements/base.txt, stevedore
 protobuf==3.13.0          # via -r requirements/base.txt, google-api-core, googleapis-common-protos
-psutil==1.2.1             # via -r requirements/base.txt, edx-django-utils, edx-drf-extensions
+psutil==5.7.2             # via -r requirements/base.txt, edx-django-utils
 pyasn1-modules==0.2.8     # via -r requirements/base.txt, google-auth
 pyasn1==0.4.8             # via -r requirements/base.txt, pyasn1-modules, rsa
-pycodestyle==2.5.0        # via -c requirements/constraints.txt, -r requirements/test.in
+pycodestyle==2.6.0        # via -r requirements/test.in
+pycparser==2.20           # via -r requirements/base.txt, cffi
 pycryptodomex==3.9.8      # via -r requirements/base.txt, pyjwkest
-pyjwkest==1.3.2           # via -r requirements/base.txt, edx-drf-extensions
-pyjwt==1.7.1              # via -r requirements/base.txt, djangorestframework-jwt
-pylint==1.9.3             # via -c requirements/constraints.txt, -r requirements/test.in
+pyjwkest==1.4.2           # via -r requirements/base.txt, edx-drf-extensions
+pyjwt[crypto]==1.7.1      # via -r requirements/base.txt, drf-jwt
+pylint==2.6.0             # via -r requirements/test.in
 pymongo==3.11.0           # via -r requirements/base.txt, edx-opaque-keys
 python-dateutil==2.8.1    # via -r requirements/base.txt, edx-drf-extensions, xblock
 pytz==2020.1              # via -r requirements/base.txt, django, edx-completion, fs, google-api-core, xblock
 pyyaml==5.3.1             # via -r requirements/base.txt, xblock
 requests==2.24.0          # via -r requirements/base.txt, edx-drf-extensions, google-api-core, pyjwkest
 rest-condition==1.0.3     # via -r requirements/base.txt, edx-drf-extensions
-rsa==4.5                  # via -r requirements/base.txt, google-auth
+rsa==4.6                  # via -r requirements/base.txt, google-auth
 semantic-version==2.8.5   # via -r requirements/base.txt, edx-drf-extensions
-singledispatch==3.4.0.3   # via astroid, pylint
-six==1.15.0               # via -r requirements/base.txt, astroid, edx-drf-extensions, edx-opaque-keys, fs, google-api-core, google-api-python-client, google-auth, google-auth-httplib2, google-cloud-bigquery, google-resumable-media, protobuf, pyjwkest, pylint, python-dateutil, singledispatch, stevedore, xblock
-stevedore==1.32.0         # via -r requirements/base.txt, edx-django-utils, edx-opaque-keys
-typing==3.7.4.3           # via -r requirements/base.txt, fs
+six==1.15.0               # via -r requirements/base.txt, astroid, cryptography, edx-drf-extensions, edx-opaque-keys, fs, google-api-core, google-api-python-client, google-auth, google-auth-httplib2, google-cloud-bigquery, google-resumable-media, protobuf, pyjwkest, python-dateutil, xblock
+sqlparse==0.3.1           # via -r requirements/base.txt, django
+stevedore==3.2.1          # via -r requirements/base.txt, edx-django-utils, edx-opaque-keys
+toml==0.10.1              # via pylint
 uritemplate==3.0.1        # via -r requirements/base.txt, google-api-python-client
 urllib3==1.25.10          # via -r requirements/base.txt, requests
 web-fragments==0.3.2      # via -r requirements/base.txt, xblock


### PR DESCRIPTION
## Background:

These changes are intended to remove Python 2.7 support and the starting point for the Juniper migration.

## Description:

This PR changes the requirements to support Python > 3 and removes unnecessary requirements.

## Note:

This PR only changes the version of the requirements, **none of the features were tested with these new versions.**

## Reviewers:

- [ ] @diegomillan 
- [ ] @luismorenolopera 