### PR TITLE
PAE-425 - Pin the Google BigQuery version.

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -9,4 +9,4 @@ edx-completion
 # These are the plugin requirements.
 # Add here any constraint needed to work with setup.py's `install_requires`.
 google-api-python-client
-google-cloud-bigquery
+google-cloud-bigquery==1.28.0

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -6,57 +6,64 @@
 #
 appdirs==1.4.4            # via fs
 cachetools==4.1.1         # via google-auth
-certifi==2020.6.20        # via requests
-cffi==1.14.2              # via cryptography, google-crc32c
+certifi==2020.11.8        # via requests
+cffi==1.14.4              # via cryptography, google-crc32c
 chardet==3.0.4            # via requests
-cryptography==3.1         # via pyjwt
-django-model-utils==4.0.0  # via edx-completion
-django-waffle==2.0.0      # via edx-django-utils, edx-drf-extensions
-django==2.2.16            # via -c requirements/constraints.txt, -r requirements/base.in, django-model-utils, drf-jwt, edx-completion, edx-django-utils, edx-drf-extensions, edx-opaque-keys, rest-condition
+click==7.1.2              # via code-annotations
+code-annotations==0.10.1  # via edx-toggles
+cryptography==3.2.1       # via pyjwt
+django-crum==0.7.9        # via edx-django-utils, edx-toggles
+django-model-utils==4.1.1  # via edx-completion
+django-waffle==2.0.0      # via edx-django-utils, edx-drf-extensions, edx-toggles
+django==2.2.17            # via -c requirements/constraints.txt, -r requirements/base.in, code-annotations, django-crum, django-model-utils, drf-jwt, edx-completion, edx-django-utils, edx-drf-extensions, edx-opaque-keys, edx-toggles, rest-condition
 djangorestframework==3.9.4  # via -c requirements/constraints.txt, -r requirements/base.in, drf-jwt, edx-completion, edx-drf-extensions, rest-condition
-drf-jwt==1.17.1           # via edx-drf-extensions
-edx-completion==3.2.4     # via -r requirements/base.in
-edx-django-utils==3.8.0   # via edx-drf-extensions
-edx-drf-extensions==6.1.2  # via edx-completion
+drf-jwt==1.17.2           # via edx-drf-extensions
+edx-completion==4.0.0     # via -r requirements/base.in
+edx-django-utils==3.13.0  # via edx-drf-extensions, edx-toggles
+edx-drf-extensions==6.2.0  # via edx-completion
 edx-opaque-keys[django]==2.1.1  # via -r requirements/base.in, edx-completion, edx-drf-extensions
+edx-toggles==1.2.0        # via edx-completion
 fs==2.4.11                # via xblock
 future==0.18.2            # via pyjwkest
-google-api-core==1.22.2   # via google-api-python-client, google-cloud-bigquery, google-cloud-core
-google-api-python-client==1.11.0  # via -r requirements/base.in
+google-api-core==1.23.0   # via google-api-python-client, google-cloud-bigquery, google-cloud-core
+google-api-python-client==1.12.8  # via -r requirements/base.in
 google-auth-httplib2==0.0.4  # via google-api-python-client
-google-auth==1.21.1       # via google-api-core, google-api-python-client, google-auth-httplib2
-google-cloud-bigquery==1.27.2  # via -r requirements/base.in
-google-cloud-core==1.4.1  # via google-cloud-bigquery
+google-auth==1.23.0       # via google-api-core, google-api-python-client, google-auth-httplib2
+google-cloud-bigquery==1.28.0  # via -c requirements/constraints.txt, -r requirements/base.in
+google-cloud-core==1.4.4  # via google-cloud-bigquery
 google-crc32c==1.0.0      # via google-resumable-media
-google-resumable-media==1.0.0  # via google-cloud-bigquery
+google-resumable-media==1.1.0  # via google-cloud-bigquery
 googleapis-common-protos==1.52.0  # via google-api-core
 httplib2==0.18.1          # via google-api-python-client, google-auth-httplib2
 idna==2.10                # via requests
-lxml==4.5.2               # via xblock
-markupsafe==1.1.1         # via xblock
-newrelic==5.18.0.148      # via edx-django-utils
-pbr==5.5.0                # via stevedore
-protobuf==3.13.0          # via google-api-core, googleapis-common-protos
-psutil==5.7.2             # via edx-django-utils
+jinja2==2.11.2            # via code-annotations
+lxml==4.6.2               # via xblock
+markupsafe==1.1.1         # via jinja2, xblock
+newrelic==5.22.1.152      # via edx-django-utils
+pbr==5.5.1                # via stevedore
+protobuf==3.14.0          # via google-api-core, googleapis-common-protos
+psutil==5.7.3             # via edx-django-utils
 pyasn1-modules==0.2.8     # via google-auth
 pyasn1==0.4.8             # via pyasn1-modules, rsa
 pycparser==2.20           # via cffi
-pycryptodomex==3.9.8      # via pyjwkest
+pycryptodomex==3.9.9      # via pyjwkest
 pyjwkest==1.4.2           # via edx-drf-extensions
 pyjwt[crypto]==1.7.1      # via drf-jwt
-pymongo==3.11.0           # via edx-opaque-keys
+pymongo==3.11.2           # via edx-opaque-keys
 python-dateutil==2.8.1    # via edx-drf-extensions, xblock
-pytz==2020.1              # via django, edx-completion, fs, google-api-core, xblock
-pyyaml==5.3.1             # via xblock
-requests==2.24.0          # via edx-drf-extensions, google-api-core, pyjwkest
+python-slugify==4.0.1     # via code-annotations
+pytz==2020.4              # via django, edx-completion, fs, google-api-core, xblock
+pyyaml==5.3.1             # via code-annotations, xblock
+requests==2.25.0          # via edx-drf-extensions, google-api-core, pyjwkest
 rest-condition==1.0.3     # via edx-drf-extensions
 rsa==4.6                  # via google-auth
 semantic-version==2.8.5   # via edx-drf-extensions
-six==1.15.0               # via cryptography, edx-drf-extensions, edx-opaque-keys, fs, google-api-core, google-api-python-client, google-auth, google-auth-httplib2, google-cloud-bigquery, google-resumable-media, protobuf, pyjwkest, python-dateutil, xblock
-sqlparse==0.3.1           # via django
-stevedore==3.2.1          # via edx-django-utils, edx-opaque-keys
+six==1.15.0               # via cryptography, edx-drf-extensions, edx-opaque-keys, fs, google-api-core, google-api-python-client, google-auth, google-auth-httplib2, google-cloud-bigquery, google-cloud-core, google-resumable-media, protobuf, pyjwkest, python-dateutil, xblock
+sqlparse==0.4.1           # via django
+stevedore==3.3.0          # via code-annotations, edx-django-utils, edx-opaque-keys
+text-unidecode==1.3       # via python-slugify
 uritemplate==3.0.1        # via google-api-python-client
-urllib3==1.25.10          # via requests
+urllib3==1.26.2           # via requests
 web-fragments==0.3.2      # via xblock
 webob==1.8.6              # via xblock
 xblock==1.4.0             # via edx-completion

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -13,3 +13,6 @@ Django<2.3
 
 # edx-platform version compatibility.
 djangorestframework==3.9.4
+
+# Python 3.5 compatibility.
+google-cloud-bigquery==1.28.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,5 +4,5 @@
 #
 #    make upgrade
 #
-bump2version==1.0.0       # via bumpversion
+bump2version==1.0.1       # via bumpversion
 bumpversion==0.6.0        # via -r requirements/dev.in

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -5,7 +5,7 @@
 #    make upgrade
 #
 click==7.1.2              # via pip-tools
-pip-tools==5.3.1          # via -r requirements/pip-tools.in
+pip-tools==5.4.0          # via -r requirements/pip-tools.in
 six==1.15.0               # via pip-tools
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -7,63 +7,70 @@
 appdirs==1.4.4            # via -r requirements/base.txt, fs
 astroid==2.4.2            # via pylint
 cachetools==4.1.1         # via -r requirements/base.txt, google-auth
-certifi==2020.6.20        # via -r requirements/base.txt, requests
-cffi==1.14.2              # via -r requirements/base.txt, cryptography, google-crc32c
+certifi==2020.11.8        # via -r requirements/base.txt, requests
+cffi==1.14.4              # via -r requirements/base.txt, cryptography, google-crc32c
 chardet==3.0.4            # via -r requirements/base.txt, requests
-cryptography==3.1         # via -r requirements/base.txt, pyjwt
-django-model-utils==4.0.0  # via -r requirements/base.txt, edx-completion
-django-waffle==2.0.0      # via -r requirements/base.txt, edx-django-utils, edx-drf-extensions
-django==2.2.16            # via -c requirements/constraints.txt, -r requirements/base.txt, django-model-utils, drf-jwt, edx-completion, edx-django-utils, edx-drf-extensions, edx-opaque-keys, rest-condition
+click==7.1.2              # via -r requirements/base.txt, code-annotations
+code-annotations==0.10.1  # via -r requirements/base.txt, edx-toggles
+cryptography==3.2.1       # via -r requirements/base.txt, pyjwt
+django-crum==0.7.9        # via -r requirements/base.txt, edx-django-utils, edx-toggles
+django-model-utils==4.1.1  # via -r requirements/base.txt, edx-completion
+django-waffle==2.0.0      # via -r requirements/base.txt, edx-django-utils, edx-drf-extensions, edx-toggles
+django==2.2.17            # via -c requirements/constraints.txt, -r requirements/base.txt, code-annotations, django-crum, django-model-utils, drf-jwt, edx-completion, edx-django-utils, edx-drf-extensions, edx-opaque-keys, edx-toggles, rest-condition
 djangorestframework==3.9.4  # via -c requirements/constraints.txt, -r requirements/base.txt, drf-jwt, edx-completion, edx-drf-extensions, rest-condition
-drf-jwt==1.17.1           # via -r requirements/base.txt, edx-drf-extensions
-edx-completion==3.2.4     # via -r requirements/base.txt
-edx-django-utils==3.8.0   # via -r requirements/base.txt, edx-drf-extensions
-edx-drf-extensions==6.1.2  # via -r requirements/base.txt, edx-completion
+drf-jwt==1.17.2           # via -r requirements/base.txt, edx-drf-extensions
+edx-completion==4.0.0     # via -r requirements/base.txt
+edx-django-utils==3.13.0  # via -r requirements/base.txt, edx-drf-extensions, edx-toggles
+edx-drf-extensions==6.2.0  # via -r requirements/base.txt, edx-completion
 edx-opaque-keys[django]==2.1.1  # via -r requirements/base.txt, edx-completion, edx-drf-extensions
+edx-toggles==1.2.0        # via -r requirements/base.txt, edx-completion
 fs==2.4.11                # via -r requirements/base.txt, xblock
 future==0.18.2            # via -r requirements/base.txt, pyjwkest
-google-api-core==1.22.2   # via -r requirements/base.txt, google-api-python-client, google-cloud-bigquery, google-cloud-core
-google-api-python-client==1.11.0  # via -r requirements/base.txt
+google-api-core==1.23.0   # via -r requirements/base.txt, google-api-python-client, google-cloud-bigquery, google-cloud-core
+google-api-python-client==1.12.8  # via -r requirements/base.txt
 google-auth-httplib2==0.0.4  # via -r requirements/base.txt, google-api-python-client
-google-auth==1.21.1       # via -r requirements/base.txt, google-api-core, google-api-python-client, google-auth-httplib2
-google-cloud-bigquery==1.27.2  # via -r requirements/base.txt
-google-cloud-core==1.4.1  # via -r requirements/base.txt, google-cloud-bigquery
+google-auth==1.23.0       # via -r requirements/base.txt, google-api-core, google-api-python-client, google-auth-httplib2
+google-cloud-bigquery==1.28.0  # via -c requirements/constraints.txt, -r requirements/base.txt
+google-cloud-core==1.4.4  # via -r requirements/base.txt, google-cloud-bigquery
 google-crc32c==1.0.0      # via -r requirements/base.txt, google-resumable-media
-google-resumable-media==1.0.0  # via -r requirements/base.txt, google-cloud-bigquery
+google-resumable-media==1.1.0  # via -r requirements/base.txt, google-cloud-bigquery
 googleapis-common-protos==1.52.0  # via -r requirements/base.txt, google-api-core
 httplib2==0.18.1          # via -r requirements/base.txt, google-api-python-client, google-auth-httplib2
 idna==2.10                # via -r requirements/base.txt, requests
-isort==5.5.1              # via pylint
+isort==5.6.4              # via pylint
+jinja2==2.11.2            # via -r requirements/base.txt, code-annotations
 lazy-object-proxy==1.4.3  # via astroid
-lxml==4.5.2               # via -r requirements/base.txt, xblock
-markupsafe==1.1.1         # via -r requirements/base.txt, xblock
+lxml==4.6.2               # via -r requirements/base.txt, xblock
+markupsafe==1.1.1         # via -r requirements/base.txt, jinja2, xblock
 mccabe==0.6.1             # via pylint
-newrelic==5.18.0.148      # via -r requirements/base.txt, edx-django-utils
-pbr==5.5.0                # via -r requirements/base.txt, stevedore
-protobuf==3.13.0          # via -r requirements/base.txt, google-api-core, googleapis-common-protos
-psutil==5.7.2             # via -r requirements/base.txt, edx-django-utils
+newrelic==5.22.1.152      # via -r requirements/base.txt, edx-django-utils
+pbr==5.5.1                # via -r requirements/base.txt, stevedore
+protobuf==3.14.0          # via -r requirements/base.txt, google-api-core, googleapis-common-protos
+psutil==5.7.3             # via -r requirements/base.txt, edx-django-utils
 pyasn1-modules==0.2.8     # via -r requirements/base.txt, google-auth
 pyasn1==0.4.8             # via -r requirements/base.txt, pyasn1-modules, rsa
 pycodestyle==2.6.0        # via -r requirements/test.in
 pycparser==2.20           # via -r requirements/base.txt, cffi
-pycryptodomex==3.9.8      # via -r requirements/base.txt, pyjwkest
+pycryptodomex==3.9.9      # via -r requirements/base.txt, pyjwkest
 pyjwkest==1.4.2           # via -r requirements/base.txt, edx-drf-extensions
 pyjwt[crypto]==1.7.1      # via -r requirements/base.txt, drf-jwt
 pylint==2.6.0             # via -r requirements/test.in
-pymongo==3.11.0           # via -r requirements/base.txt, edx-opaque-keys
+pymongo==3.11.2           # via -r requirements/base.txt, edx-opaque-keys
 python-dateutil==2.8.1    # via -r requirements/base.txt, edx-drf-extensions, xblock
-pytz==2020.1              # via -r requirements/base.txt, django, edx-completion, fs, google-api-core, xblock
-pyyaml==5.3.1             # via -r requirements/base.txt, xblock
-requests==2.24.0          # via -r requirements/base.txt, edx-drf-extensions, google-api-core, pyjwkest
+python-slugify==4.0.1     # via -r requirements/base.txt, code-annotations
+pytz==2020.4              # via -r requirements/base.txt, django, edx-completion, fs, google-api-core, xblock
+pyyaml==5.3.1             # via -r requirements/base.txt, code-annotations, xblock
+requests==2.25.0          # via -r requirements/base.txt, edx-drf-extensions, google-api-core, pyjwkest
 rest-condition==1.0.3     # via -r requirements/base.txt, edx-drf-extensions
 rsa==4.6                  # via -r requirements/base.txt, google-auth
 semantic-version==2.8.5   # via -r requirements/base.txt, edx-drf-extensions
-six==1.15.0               # via -r requirements/base.txt, astroid, cryptography, edx-drf-extensions, edx-opaque-keys, fs, google-api-core, google-api-python-client, google-auth, google-auth-httplib2, google-cloud-bigquery, google-resumable-media, protobuf, pyjwkest, python-dateutil, xblock
-sqlparse==0.3.1           # via -r requirements/base.txt, django
-stevedore==3.2.1          # via -r requirements/base.txt, edx-django-utils, edx-opaque-keys
-toml==0.10.1              # via pylint
+six==1.15.0               # via -r requirements/base.txt, astroid, cryptography, edx-drf-extensions, edx-opaque-keys, fs, google-api-core, google-api-python-client, google-auth, google-auth-httplib2, google-cloud-bigquery, google-cloud-core, google-resumable-media, protobuf, pyjwkest, python-dateutil, xblock
+sqlparse==0.4.1           # via -r requirements/base.txt, django
+stevedore==3.3.0          # via -r requirements/base.txt, code-annotations, edx-django-utils, edx-opaque-keys
+text-unidecode==1.3       # via -r requirements/base.txt, python-slugify
+toml==0.10.2              # via pylint
 uritemplate==3.0.1        # via -r requirements/base.txt, google-api-python-client
-urllib3==1.25.10          # via -r requirements/base.txt, requests
+urllib3==1.26.2           # via -r requirements/base.txt, requests
 web-fragments==0.3.2      # via -r requirements/base.txt, xblock
 webob==1.8.6              # via -r requirements/base.txt, xblock
 wrapt==1.12.1             # via astroid


### PR DESCRIPTION
## Description:

This PR sets the Google BigQuery version to 1.28.0 because it is the last version that Python 3.5 supports.

## Reviewers:

- [ ] @diegomillan 
- [ ] @luismorenolopera 