### PR TITLE
PAE-527.1 - Fix response when Celery task fails.

### DIFF
--- a/openedx_pearson_reports/api/v1/views.py
+++ b/openedx_pearson_reports/api/v1/views.py
@@ -111,11 +111,11 @@ class GetReportView(APIView):
             logger.info(
                 "The task with id = %s has been finalized with the following error %s.",
                 task.id,
-                task.info.message
+                task.info,
             )
 
             try:
-                response_data = json.loads(task.result.message)
+                response_data = json.loads(task.result)
             except ValueError:
                 response_data['status'] = status.HTTP_500_INTERNAL_SERVER_ERROR
 


### PR DESCRIPTION
## Description:

This PR fixes the GET response when the Celery task fails.

## Reviewers:

- [ ] @diegomillan 
- [ ] @luismorenolopera 